### PR TITLE
PEWI-71 Support the target attribute

### DIFF
--- a/templates/bean--adventure.tpl.php
+++ b/templates/bean--adventure.tpl.php
@@ -23,7 +23,7 @@
           <?php endif; ?>
 
           <?php if (isset($bean->field_adventure_url['und'][0]['url'])): ?>
-          <a class="bean-adventure_button" href="<?php print $bean->field_adventure_url['und'][0]['url']; ?>"><?php print $bean->field_adventure_url['und'][0]['title']; ?></a>
+          <a class="bean-adventure_button" href="<?php print $bean->field_adventure_url['und'][0]['url']; ?>" target="<?php print $bean->field_adventure_url['und'][0]['attributes']['target']; ?>"><?php print $bean->field_adventure_url['und'][0]['title']; ?></a>
           <?php endif; ?>
         </div>
       </div>

--- a/templates/bean--adventure.tpl.php
+++ b/templates/bean--adventure.tpl.php
@@ -23,8 +23,10 @@
           <?php endif; ?>
 
           <?php if (isset($bean->field_adventure_url['und'][0]['url'])): ?>
-          <a class="bean-adventure_button" href="<?php print $bean->field_adventure_url['und'][0]['url']; ?>" target="<?php print $bean->field_adventure_url['und'][0]['attributes']['target']; ?>"><?php print $bean->field_adventure_url['und'][0]['title']; ?></a>
+          
+          <a class="bean-adventure_button" href="<?php print $bean->field_adventure_url['und'][0]['url']; ?>" <?php if (isset($bean->field_adventure_url['und'][0]['attributes']['target'])): ?>target="<?php print $bean->field_adventure_url['und'][0]['attributes']['target']; ?>"<?php endif; ?>><?php print $bean->field_adventure_url['und'][0]['title']; ?></a>
           <?php endif; ?>
+          
         </div>
       </div>
 


### PR DESCRIPTION
This adds support for the link target attribute for the caption so, if that's enabled for someone's implementation of adventure banner, it will show up in the HTML. This was requested by PEWI and seems like a good thing to add.

To test, get Adventure Bean on a site, edit the block type to enable the option to open a link in a new window. Then make a place a banner. Test with and without checking the box to open in a new window. 